### PR TITLE
Add basic padel ball tracking framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# PadelHawkEye
+# Padel HawkEye
+
+This repository contains a simple implementation to process padel match videos from a fixed camera. The program detects the ball, estimates its trajectory and checks that the camera view remains calibrated.
+
+## Requirements
+
+- Python 3
+- OpenCV
+- NumPy
+- SciPy (for polynomial fitting)
+
+Install dependencies:
+
+```bash
+pip install opencv-python numpy scipy
+```
+
+## Usage
+
+Run the main program with a video file or camera source:
+
+```bash
+python main.py --video path/to/video.mp4
+```
+
+To specify initial calibration points (pixels) use `--points` with eight comma-separated values `x1,y1,x2,y2,x3,y3,x4,y4` representing the court corners in order.
+
+Press `q` to quit.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,77 @@
+import argparse
+import cv2
+from padel.video import VideoSource
+from padel.calibration import CourtCalibrator
+from padel.ball import BallDetector
+from padel.validator import FrameValidator
+from padel.predictor import TrajectoryPredictor
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Padel HawkEye demo")
+    parser.add_argument("--video", help="Path or URL of video source", default=0)
+    parser.add_argument("--points", help="Initial calibration points x1,y1,x2,y2,x3,y3,x4,y4", default=None)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    src = VideoSource(args.video)
+
+    ref_points = None
+    if args.points:
+        nums = [float(x) for x in args.points.split(',')]
+        ref_points = [(nums[0], nums[1]), (nums[2], nums[3]),
+                      (nums[4], nums[5]), (nums[6], nums[7])]
+    calibrator = CourtCalibrator(reference_points=ref_points)
+    detector = BallDetector()
+    validator = FrameValidator()
+    predictor = TrajectoryPredictor()
+
+    while True:
+        frame = src.read()
+        if frame is None:
+            break
+
+        if not validator.is_valid(frame):
+            cv2.putText(frame, "Invalid view", (10, 30), cv2.FONT_HERSHEY_SIMPLEX,
+                        1, (0, 0, 255), 2)
+            cv2.imshow("Padel", frame)
+            if cv2.waitKey(1) & 0xFF == ord('q'):
+                break
+            continue
+
+        if calibrator.homography is None:
+            calibrator.calibrate(frame)
+
+        ball_pos = detector.detect(frame)
+        if ball_pos is not None:
+            world = calibrator.pixel_to_world(ball_pos)
+            predictor.add_point(world)
+            cv2.circle(frame, ball_pos, 5, (0, 255, 0), -1)
+            cv2.putText(frame, f"{world[0]:.2f}, {world[1]:.2f}",
+                        (ball_pos[0]+10, ball_pos[1]-10),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
+        prediction = predictor.predict()
+        if prediction is not None and calibrator.homography is not None:
+            # Convert world prediction back to pixel for visualization.
+            inv_h = cv2.invert(calibrator.homography)[1]
+            pt = calibrator.homography @ [[prediction[0]], [prediction[1]], [1]]
+        trajectory_points = [calibrator.homography @ [[p[0]], [p[1]], [1]] for p in predictor.points]
+        for i in range(1, len(trajectory_points)):
+            p1 = trajectory_points[i-1]
+            p2 = trajectory_points[i]
+            p1 = (int(p1[0]/p1[2]), int(p1[1]/p1[2]))
+            p2 = (int(p2[0]/p2[2]), int(p2[1]/p2[2]))
+            cv2.line(frame, p1, p2, (255, 0, 0), 2)
+
+        cv2.imshow("Padel", frame)
+        if cv2.waitKey(1) & 0xFF == ord('q'):
+            break
+
+    src.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()

--- a/padel/ball.py
+++ b/padel/ball.py
@@ -1,0 +1,25 @@
+import cv2
+import numpy as np
+
+class BallDetector:
+    """Detect the padel ball in frames."""
+
+    def __init__(self, lower_color=(30, 150, 100), upper_color=(50, 255, 255)):
+        """Initialize detector with color range in HSV."""
+        self.lower_color = np.array(lower_color, dtype=np.uint8)
+        self.upper_color = np.array(upper_color, dtype=np.uint8)
+
+    def detect(self, frame):
+        """Return the center of the detected ball in pixel coordinates."""
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+        mask = cv2.inRange(hsv, self.lower_color, self.upper_color)
+        mask = cv2.erode(mask, None, iterations=2)
+        mask = cv2.dilate(mask, None, iterations=2)
+        cnts, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if not cnts:
+            return None
+        c = max(cnts, key=cv2.contourArea)
+        ((x, y), radius) = cv2.minEnclosingCircle(c)
+        if radius < 2:
+            return None
+        return int(x), int(y)

--- a/padel/calibration.py
+++ b/padel/calibration.py
@@ -1,0 +1,48 @@
+import cv2
+import numpy as np
+
+class CourtCalibrator:
+    """Detect court lines and compute homography."""
+
+    def __init__(self, reference_points=None, real_width=20.0, real_height=10.0):
+        """Initialize the calibrator.
+
+        Args:
+            reference_points: Optional list of four points [(x, y), ...] in
+                image coordinates corresponding to court corners.
+            real_width: Width of the court in meters.
+            real_height: Height of the court in meters.
+        """
+        self.reference_points = reference_points
+        self.real_width = real_width
+        self.real_height = real_height
+        self.homography = None
+
+    def calibrate(self, frame):
+        """Calibrate using the provided frame."""
+        if self.reference_points is None:
+            # Detect lines via Hough transform (simplified example).
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            edges = cv2.Canny(gray, 50, 150, apertureSize=3)
+            lines = cv2.HoughLinesP(edges, 1, np.pi / 180, 100,
+                                    minLineLength=100, maxLineGap=10)
+            if lines is None:
+                return False
+            # Placeholder: Use image corners as approximate reference.
+            h, w = frame.shape[:2]
+            self.reference_points = [(0, 0), (w, 0), (w, h), (0, h)]
+        pts_src = np.array(self.reference_points, dtype=np.float32)
+        pts_dst = np.array([[0, 0], [self.real_width, 0],
+                            [self.real_width, self.real_height],
+                            [0, self.real_height]], dtype=np.float32)
+        self.homography, _ = cv2.findHomography(pts_src, pts_dst)
+        return self.homography is not None
+
+    def pixel_to_world(self, point):
+        """Map pixel coordinates to world coordinates using homography."""
+        if self.homography is None:
+            raise ValueError("Calibrator has not been fitted")
+        px = np.array([[point[0], point[1], 1]], dtype=np.float32).T
+        world = self.homography @ px
+        world /= world[2, 0]
+        return float(world[0, 0]), float(world[1, 0])

--- a/padel/predictor.py
+++ b/padel/predictor.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+class TrajectoryPredictor:
+    """Predict trajectory using recent positions."""
+
+    def __init__(self, maxlen=10):
+        self.maxlen = maxlen
+        self.points = []
+
+    def add_point(self, point):
+        if point is None:
+            return
+        self.points.append(point)
+        if len(self.points) > self.maxlen:
+            self.points.pop(0)
+
+    def predict(self):
+        if len(self.points) < 3:
+            return None
+        pts = np.array(self.points)
+        t = np.arange(len(pts))
+        coeffs_x = np.polyfit(t, pts[:, 0], 2)
+        coeffs_y = np.polyfit(t, pts[:, 1], 2)
+        next_t = len(pts)
+        pred_x = np.polyval(coeffs_x, next_t)
+        pred_y = np.polyval(coeffs_y, next_t)
+        return int(pred_x), int(pred_y)

--- a/padel/validator.py
+++ b/padel/validator.py
@@ -1,0 +1,27 @@
+import cv2
+import numpy as np
+
+class FrameValidator:
+    """Check if the current frame matches the calibrated view."""
+
+    def __init__(self, reference_frame=None, threshold=10):
+        self.reference_hash = None
+        self.threshold = threshold
+        if reference_frame is not None:
+            self.reference_hash = self._phash(reference_frame)
+
+    def _phash(self, frame):
+        resized = cv2.resize(frame, (32, 32))
+        gray = cv2.cvtColor(resized, cv2.COLOR_BGR2GRAY)
+        dct = cv2.dct(np.float32(gray))
+        dct_low = dct[:8, :8]
+        med = np.median(dct_low)
+        return (dct_low > med).astype(int)
+
+    def is_valid(self, frame):
+        if self.reference_hash is None:
+            self.reference_hash = self._phash(frame)
+            return True
+        current_hash = self._phash(frame)
+        diff = np.sum(current_hash != self.reference_hash)
+        return diff < self.threshold

--- a/padel/video.py
+++ b/padel/video.py
@@ -1,0 +1,24 @@
+import cv2
+
+class VideoSource:
+    """Manage video input from file or camera."""
+
+    def __init__(self, path: str = 0):
+        """Initialize the video source.
+
+        Args:
+            path: Path to video file or camera index/URL.
+        """
+        self.cap = cv2.VideoCapture(path)
+        if not self.cap.isOpened():
+            raise ValueError(f"Unable to open video source: {path}")
+
+    def read(self):
+        """Read a frame from the video source."""
+        ret, frame = self.cap.read()
+        if not ret:
+            return None
+        return frame
+
+    def release(self):
+        self.cap.release()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+opencv-python
+numpy
+scipy


### PR DESCRIPTION
## Summary
- create basic module structure for ball tracking
- implement ball detection, trajectory prediction, frame validation, and homography calibration
- add runnable `main.py` and installation instructions

## Testing
- `python3 -m py_compile padel/video.py padel/calibration.py padel/ball.py padel/validator.py padel/predictor.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_684f326be3f483298958939f426774ec